### PR TITLE
Added info about 'square' images in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ videoshow(images, videoOptions)
   })
 ```
 
+The images should be squared before use.
 Take a look to the [programmatic API](#api) for more details
 
 ## Command-line interface


### PR DESCRIPTION
Got stuck for a while when using non squared images.