### PR TITLE
Bumping fluent-ffmpeg 2.0.1 -> 2.1.0 | Bumping videoShow 0.1.9 -> 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videoshow",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Simple command-line and programmatic interface to create videos slideshows from images using ffmpeg",
   "repository": "h2non/videoshow",
   "author": "Tomas Aparicio",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "ass-stringify": "^0.1.1",
-    "fluent-ffmpeg": "^2.0.0",
+    "fluent-ffmpeg": "^2.1.0",
     "fw": "^0.1.2",
     "lil-uuid": "^0.1.0",
     "lodash.merge": "^3.0.0",


### PR DESCRIPTION
btw npm test fails on test "create video with custom captions per images". This happens on existing 0.1.9 master as well so it's not a new change from my pull request. 