### PR TITLE
fixing videoOptions on addLogo method

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -167,7 +167,9 @@ function renderVideo(videoshow, options, forwardEvent, cb) {
     copy(output, tempfile, function (err) {
       if (err) return cb(err)
 
-      ffmpeg(tempfile)
+      var logo = ffmpeg(tempfile)
+      applyVideoOptions(logo, videoOptions)
+      logo
         .input(videoOptions.logo)
         .complexFilter(logoFilter(videoshow))
         .on('error', clean(cb))


### PR DESCRIPTION
To add videoshow#options in all ffmpeg commands we need this.
Without this I am unable to add custom output option as command-line flag. If it is correct please accept this PR. 