### PR TITLE
docs: fix console type

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ videoshow(images, videoOptions)
     console.error('ffmpeg stderr:', stderr)
   })
   .on('end', function (output) {
-    console.error('Video created in:', output)
+    console.log('Video created in:', output)
   })
 ```
 


### PR DESCRIPTION
Adjusting console type, in the case of `on('end'...` should not set type `error`